### PR TITLE
Release v0.0.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,9 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-commit]
+
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v3.30.0
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+## [0.0.3] - 2025-09-20
+
+### feat
+- semantic versioning + release helpers; centralize tool configs; set initial version 0.0.1\n\n- dev version current|bump <major|minor|patch> with CHANGELOG generation and annotated tags\n- dev release rc to create/push release-candidate\n- dev protect-main uses gh CLI to enable branch protection\n- Commitizen pre-commit commit-msg hook enforcing Conventional Commits\n- Configs in pyproject (ruff, mypy, pytest, commitizen)\n- Docs version set to 0.0.1 (6072fed)
+
+### refactor
+- modernize dev CLI and wire up uv entry point\n\n- Replace if-chain with match-case; add is_ci() and run_mypy_then()\n- Improve typing and docstrings; simplify ruff checks\n- Update wrapper entrypoints to call local main()\n- Add build-system (hatchling) and src/ layout packaging config\n- Configure [project.scripts] dev entry point; default dev dependency group via [tool.uv]\n- Add package __init__.py\n\nRun with: uv run dev --help (5875223)
+
+### ci
+- add GitHub Actions workflow; update pre-commit stages; make dev check treat no-tests (pytest rc=5) as success (9066908)
+
+### chore
+- centralize tool configs in pyproject (ruff, mypy, pytest); add return type to main() (65d5948)
+- remove stale erasmus entrypoint and add pre-commit hook to run 'uv run dev check' (2963923)
+
+### other
+- Initial commit (fcbcabd)
+
+## [0.0.2] - 2025-09-20
+
+### feat
+- semantic versioning + release helpers; centralize tool configs; set initial version 0.0.1\n\n- dev version current|bump <major|minor|patch> with CHANGELOG generation and annotated tags\n- dev release rc to create/push release-candidate\n- dev protect-main uses gh CLI to enable branch protection\n- Commitizen pre-commit commit-msg hook enforcing Conventional Commits\n- Configs in pyproject (ruff, mypy, pytest, commitizen)\n- Docs version set to 0.0.1 (6072fed)
+
+### refactor
+- modernize dev CLI and wire up uv entry point\n\n- Replace if-chain with match-case; add is_ci() and run_mypy_then()\n- Improve typing and docstrings; simplify ruff checks\n- Update wrapper entrypoints to call local main()\n- Add build-system (hatchling) and src/ layout packaging config\n- Configure [project.scripts] dev entry point; default dev dependency group via [tool.uv]\n- Add package __init__.py\n\nRun with: uv run dev --help (5875223)
+
+### ci
+- add GitHub Actions workflow; update pre-commit stages; make dev check treat no-tests (pytest rc=5) as success (9066908)
+
+### chore
+- centralize tool configs in pyproject (ruff, mypy, pytest); add return type to main() (65d5948)
+- remove stale erasmus entrypoint and add pre-commit hook to run 'uv run dev check' (2963923)
+
+### other
+- Initial commit (fcbcabd)
+
+## [0.0.2] - 2025-09-20
+
+### feat
+- semantic versioning + release helpers; centralize tool configs; set initial version 0.0.1\n\n- dev version current|bump <major|minor|patch> with CHANGELOG generation and annotated tags\n- dev release rc to create/push release-candidate\n- dev protect-main uses gh CLI to enable branch protection\n- Commitizen pre-commit commit-msg hook enforcing Conventional Commits\n- Configs in pyproject (ruff, mypy, pytest, commitizen)\n- Docs version set to 0.0.1 (6072fed)
+
+### refactor
+- modernize dev CLI and wire up uv entry point\n\n- Replace if-chain with match-case; add is_ci() and run_mypy_then()\n- Improve typing and docstrings; simplify ruff checks\n- Update wrapper entrypoints to call local main()\n- Add build-system (hatchling) and src/ layout packaging config\n- Configure [project.scripts] dev entry point; default dev dependency group via [tool.uv]\n- Add package __init__.py\n\nRun with: uv run dev --help (5875223)
+
+### ci
+- add GitHub Actions workflow; update pre-commit stages; make dev check treat no-tests (pytest rc=5) as success (9066908)
+
+### chore
+- centralize tool configs in pyproject (ruff, mypy, pytest); add return type to main() (65d5948)
+- remove stale erasmus entrypoint and add pre-commit hook to run 'uv run dev check' (2963923)
+
+### other
+- Initial commit (fcbcabd)
+
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to Greeble
+
+Thank you for your interest in contributing! This document defines our contribution process so changes land quickly and safely.
+
+## Quick Start
+
+- Create a branch from `main` for your change:
+  - `git checkout -b feat/<short-topic>` or `git checkout -b fix/<short-topic>` or `git checkout -b docs/<short-topic>`
+- Make changes and commit using Conventional Commits (see below).
+- Push your branch, then finalize to the release-candidate branch:
+  - `uv run dev branch-finalize`
+- Open the release PR from `release-candidate` to `main`:
+  - `uv run dev release-pr`
+- A maintainer will review and merge via PR. Releases are cut from `main` using `uv run dev version bump <part>`.
+
+## Conventional Commits
+
+Use the following format for commit messages:
+
+```
+<type>(<scope>): <subject>
+
+<body>
+```
+
+- Types: `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+- Subject: short imperative summary (lowercase, no period)
+- Scope (optional): area touched, e.g., `scripts`, `docs`, `table`
+- Body (optional): motivation, context, breaking changes
+
+Examples:
+- `feat(components): add modal component`
+- `fix(django): use correct CSRF header name`
+- `docs: clarify contribution flow`
+
+Commit messages are validated by pre-commit (Commitizen).
+
+## Branching Model
+
+- `main` is protected and only changed via Pull Requests.
+- `release-candidate` aggregates accepted feature branches prior to release.
+- Feature branches: `feat/*`, `fix/*`, `docs/*`, etc.
+
+Flow:
+1. Create a feature branch from `main`.
+2. Push commits (Conventional Commits enforced).
+3. Finalize your branch into `release-candidate`:
+   - `uv run dev branch-finalize`
+4. Open a PR from `release-candidate` to `main`:
+   - `uv run dev release-pr`
+5. A maintainer reviews and merges the PR to `main`.
+
+## Versioning & Changelog
+
+- Semantic Versioning (SemVer) per project: `MAJOR.MINOR.PATCH`.
+- Current version lives in `pyproject.toml` under `[project].version`.
+- Bumping versions creates tags and prepends a changelog section based on Conventional Commits since the last tag:
+  - `uv run dev version bump patch`
+  - `uv run dev version bump minor`
+  - `uv run dev version bump major`
+- Push the release commit and tag:
+  - `git push && git push --tags`
+
+## Tooling
+
+- Python: 3.12+
+- Package manager: `uv`
+- Linting/Formatting: `ruff`
+- Type checking: `mypy`
+- Tests: `pytest`
+- Hooks: `pre-commit` (runs `uv run dev check`) and Commitizen (`commit-msg`)
+
+Run checks locally:
+
+```
+uv run dev check
+```
+
+## Code Style
+
+- Follow Ruff and Black-compatible formatting (enforced by `ruff format`).
+- Prefer standard library and small, focused functions.
+- Add type hints everywhere (`-> None` for no-return functions).
+
+## Documentation
+
+- Update or add docs under `docs/` when user-facing behavior changes.
+- If adding components or patterns, include examples and accessibility guidance.
+
+## Accessibility
+
+- Ensure components are usable with keyboard only.
+- Provide ARIA roles/names and manage focus where applicable.
+- Announce dynamic updates via `aria-live` when needed.
+
+## Security
+
+- Validate server-side inputs for all state-changing requests.
+- Be mindful of CSRF in adapters; include CSRF headers for HTMX requests.
+
+## Questions
+
+Open a discussion or issue if anything is unclear. Thank you for contributing!

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Richard Bakobiibizo
+Copyright (c) 2025 Richard Porteous, aka Bakobiibizo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,703 @@
+# Greeble: Architecture and Design Document
+
+**Version:** 0.0.1
+**Audience:** Python-first web developers building server-rendered interfaces with HTMX
+**Authoring mode:** HTML-first, progressive enhancement, copy and paste components
+
+---
+
+## 1. Purpose
+
+Greeble is an HTML-first component library that delivers copy and paste snippets powered by HTMX for rapid UI construction. The library targets Python frameworks first (Django, FastAPI, Flask), while remaining backend agnostic. The goal is to provide a set of accessible, unopinionated building blocks that work without a JavaScript bundler, can be themed with design tokens, and define predictable server contracts.
+
+## 2. Goals
+
+1. Copy and paste components that work out of the box with HTMX, no bundler required.
+2. First-class documentation and adapters for Django, FastAPI, and Flask.
+3. Accessible by default, including keyboard flows, focus management, and ARIA roles.
+4. Theming through CSS variables and an optional Tailwind preset. No lock-in.
+5. Predictable server contracts: each component declares expected endpoints, inputs, events, and return shapes.
+6. Ownership of source: the CLI copies files into the application so teams can modify freely.
+
+## 3. Non-Goals
+
+1. A full reactive component framework. Greeble enhances server-rendered HTML instead of replacing it.
+2. Shipping a runtime JavaScript framework. The baseline is HTMX and optional Hyperscript.
+3. Locking teams into a specific CSS utility framework. Tailwind support is an add-on.
+
+## 4. Core Principles
+
+* **HTML first:** render everything on the server, apply interactivity through HTMX attributes.
+* **Progressive enhancement:** components function without client scripting, then enhance behavior when HTMX is present.
+* **Accessibility by default:** roles, names, focus management, and keyboard interaction are designed in from the start.
+* **Stable contracts:** the markup API and server contract are explicit and versioned.
+* **Learn by viewing source:** every example page exposes the exact HTML that gets pasted.
+
+---
+
+## 5. High-Level Architecture
+
+### 5.1 Package Layout
+
+```
+greeble/
+  packages/
+    greeble-core/                # CSS tokens, resets, low-level utilities
+    greeble-components/          # Copy and paste HTML snippets with HTMX attributes
+    greeble-hyperscript/         # Optional interactions as <script type="text/hyperscript">
+    greeble-tailwind-preset/     # Optional Tailwind preset mapped to CSS variables
+    adapters/
+      greeble-django/            # Template tags, CSRF helpers, messages-to-toasts, pagination helpers
+      greeble-fastapi/           # Template utilities, partial helpers, HX-Trigger helpers
+      greeble-flask/             # Blueprint with helpers matching the FastAPI adapter
+  tools/
+    greeble-cli/                 # `greeble add <component>` copies component files into the app
+  docs/
+    site/                        # Documentation site with live examples and source view
+  examples/
+    fastapi-demo/
+    django-demo/
+    flask-demo/
+```
+
+### 5.2 Runtime Overview
+
+* Components are HTML fragments with HTMX attributes and CSS classes.
+* The server returns partial templates that replace targets or apply out of band swaps.
+* Optional Hyperscript snippets handle focus, keyboard navigation, and small behaviors without a bundler.
+* The adapters provide ergonomics for CSRF, flash messages, and HTMX-aware rendering.
+
+### 5.3 Data Flow
+
+1. A user action triggers an HTMX request via `hx-get` or `hx-post`.
+2. The server endpoint validates input, executes domain logic, and returns an HTML fragment.
+3. HTMX swaps the fragment into the target element. Optional out of band fragments update shared zones such as a toast container.
+4. Optional custom events inform other components about state changes.
+
+---
+
+## 6. Styling and Theming
+
+### 6.1 Design Tokens
+
+A small set of CSS variables controls colors, spacing, radii, shadows, and transitions. These are defined in `greeble-core` and can be overridden on `:root` or on a theme scope.
+
+```css
+:root {
+  --greeble-color-background: #0b0b0c;
+  --greeble-color-foreground: #e8e8ea;
+  --greeble-color-muted: #a0a0a7;
+  --greeble-color-accent: #6aa1ff;
+  --greeble-radius-medium: 12px;
+  --greeble-shadow-1: 0 1px 2px rgba(0,0,0,.2);
+  --greeble-shadow-2: 0 8px 30px rgba(0,0,0,.35);
+  --greeble-spacing-1: .25rem;
+  --greeble-spacing-2: .5rem;
+  --greeble-spacing-3: .75rem;
+  --greeble-spacing-4: 1rem;
+  --greeble-focus-ring: 0 0 0 3px rgba(106,161,255,.5);
+}
+```
+
+### 6.2 Utility Classes
+
+`greeble-core` includes a light utility sheet for common layout patterns: stack, cluster, grid, visually hidden, and focus ring helpers. Teams can keep these or replace them.
+
+### 6.3 Tailwind Preset
+
+`greeble-tailwind-preset` maps the CSS variables to Tailwind theme tokens. Teams using Tailwind can opt in without rewriting components.
+
+---
+
+## 7. Component Specification Format
+
+Each component ships with:
+
+* `component.html` (trigger markup that lives in your page)
+* `component.partial.html` (server-rendered fragment that gets returned by endpoints)
+* `component.hyperscript.html` (optional behavior)
+* `README.md` (contract and accessibility guidance)
+
+Each component must document:
+
+* **Inputs:** data attributes, form fields, and ARIA attributes.
+* **Endpoints:** routes, HTTP methods, expected parameters, and return fragments.
+* **Events:** custom events emitted or consumed.
+* **Accessibility:** roles, names, keyboard interactions, and focus management.
+* **States:** loading, error, empty, and success visuals.
+* **Theming hooks:** tokens and classes involved.
+
+### 7.1 Example: Modal Component
+
+**Trigger Markup**
+
+```html
+<button
+  class="greeble-button"
+  hx-get="/modal/example"
+  hx-target="#modal-root"
+  hx-trigger="click"
+  hx-swap="innerHTML">
+  Open Modal
+</button>
+
+<div id="modal-root" aria-live="polite"></div>
+```
+
+**Returned Partial**
+
+```html
+<div
+  id="greeble-modal"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="greeble-modal-title"
+  class="greeble-modal"
+  _="on load call #greeble-modal.focus()">
+  <div class="greeble-modal__backdrop"
+       hx-trigger="click"
+       hx-get="/modal/close"
+       hx-target="#modal-root"
+       hx-swap="innerHTML"></div>
+
+  <div class="greeble-modal__panel" tabindex="-1">
+    <header class="greeble-modal__header">
+      <h2 id="greeble-modal-title" class="greeble-heading-2">Example modal</h2>
+      <button class="greeble-icon-button"
+              aria-label="Close"
+              hx-get="/modal/close"
+              hx-target="#modal-root"
+              hx-swap="innerHTML">×</button>
+    </header>
+
+    <div class="greeble-modal__body">
+      <p>Content here</p>
+      <form
+        hx-post="/modal/submit"
+        hx-target="#modal-root"
+        hx-swap="innerHTML">
+        <input name="email" type="email" required class="greeble-input" />
+        <button class="greeble-button greeble-button--accent" type="submit">Submit</button>
+      </form>
+    </div>
+  </div>
+</div>
+```
+
+**Server Endpoints**
+
+* `GET /modal/example` returns the modal partial
+* `GET /modal/close` returns an empty string
+* `POST /modal/submit` returns a success partial or validation errors
+
+**Accessibility**
+
+* Focus sent to the panel on open, Escape closes via a visible close button or an optional key handler in Hyperscript.
+* Backdrop has a descriptive label on the dialog container, not on the backdrop itself.
+
+---
+
+## 8. Python Adapters
+
+### 8.1 Django Adapter
+
+* Template tag `{% greeble_toast_container %}` injects a single toast root.
+* Template tag `{% greeble_csrf_headers %}` prints `hx-headers` for CSRF.
+* Middleware converts `django.contrib.messages` into out of band toast fragments.
+* Pagination helper generates `hx-get` links targeting a table body.
+
+### 8.2 FastAPI Adapter
+
+* `HTMXPartial` response helper for fragments, with optional event triggers via `HX-Trigger` headers.
+* Jinja2 template utilities for deciding layout versus partial based on the `HX-Request` header.
+
+### 8.3 Flask Adapter
+
+* Blueprint with helpers matching FastAPI semantics.
+
+---
+
+## 9. CLI
+
+### 9.1 Purpose
+
+The CLI copies component files into the application, initializes tokens and utilities, and optionally installs a Tailwind preset.
+
+### 9.2 Commands
+
+```
+greeble add <component-name>
+greeble add table --features pagination,sorting
+greeble theme init --preset minimal
+greeble doctor
+```
+
+### 9.3 Behavior
+
+* Verifies destination paths and writes files under `templates/greeble` and `static/greeble` by default.
+* Never hides files. The application owns and edits all copied files.
+* Prints follow-up instructions for wiring endpoints and optional adapter helpers.
+
+---
+
+## 10. Events and Swap Conventions
+
+* Loading indicators: use `hx-indicator=".greeble-loading"` on a component root that contains a spinner element.
+* Error handling: fragments can mark error roots with `data-greeble-error="true"` so styles can switch to an error state.
+* Out of band zones: `#greeble-toasts` for toasts, `#greeble-dialog-root` for modals, `#greeble-announcer` for live regions.
+* Custom events: components may emit `greeble:success`, `greeble:error`, or more specific events.
+
+---
+
+## 11. Accessibility Requirements
+
+* All interactive elements are keyboard reachable and operable.
+* Dialogs manage focus and restore focus to the trigger on close.
+* Menus and lists use roving tabindex when appropriate.
+* All form controls have programmatic names and visible labels.
+* Announce dynamic updates through `aria-live` regions when content changes non-modally.
+
+---
+
+## 12. Security Considerations
+
+* CSRF documentation per framework, plus helpers for headers on HTMX requests.
+* Validation on server endpoints for state-changing requests, even when triggered by HTMX.
+* Rate limits for high-frequency triggers, such as typeahead and command palette.
+* Clear guidance on safely rendering untrusted content in fragments.
+
+---
+
+## 13. Versioning and Stability
+
+* Semantic versioning for all packages.
+* `greeble-components` treats any change to HTML structure, required attributes, or data attributes as a breaking change that bumps the major version.
+* Adapters maintain minor version compatibility within a major series.
+
+---
+
+## 14. Testing and Quality
+
+* Example servers in `examples/` for FastAPI, Django, and Flask, each rendering every component.
+* Playwright-based snapshot tests for visual regressions.
+* `axe-core` automated accessibility checks on example pages.
+* Contract tests that render fragments with sample context to validate required fields and states.
+
+---
+
+## 15. Initial Component Catalog
+
+Each entry includes a summary, expected endpoints, events, and accessibility notes. The manifest below encodes these details for scaffolding.
+
+### 15.1 Buttons
+
+* **Summary:** Primary, secondary, icon, and split buttons.
+* **Endpoints:** None, buttons act as triggers.
+* **Events:** Emit `greeble:click` as an optional custom event.
+* **Accessibility:** Visible focus, `aria-pressed` for toggle variants.
+
+### 15.2 Inputs
+
+* **Summary:** Text input, textarea, select, and a combobox pattern.
+* **Endpoints:** Validation endpoint optional.
+* **Events:** `greeble:validate` optional.
+* **Accessibility:** Labeled controls, `aria-describedby` for help text and errors.
+
+### 15.3 Modal
+
+* **Summary:** Dialog with focus trap, backdrop, and close controls.
+* **Endpoints:** `GET /modal/example`, `GET /modal/close`, `POST /modal/submit`.
+* **Events:** `greeble:modal:open`, `greeble:modal:close`.
+* **Accessibility:** `role="dialog"`, `aria-modal="true"`, managed focus.
+
+### 15.4 Drawer
+
+* **Summary:** Edge panel for settings and filters.
+* **Endpoints:** Open, close, and optional save.
+* **Events:** `greeble:drawer:open`, `greeble:drawer:close`.
+* **Accessibility:** `role="dialog"` with labeled header.
+
+### 15.5 Dropdown Menu
+
+* **Summary:** Button-triggered menu with keyboard navigation.
+* **Endpoints:** None required, content is server-rendered or static.
+* **Events:** `greeble:menu:select`.
+* **Accessibility:** `role="menu"`, roving tabindex, arrow key navigation.
+
+### 15.6 Tabs
+
+* **Summary:** Tablist with per-tab content via `hx-get`.
+* **Endpoints:** `GET /tabs/<tab>`.
+* **Events:** `greeble:tab:change`.
+* **Accessibility:** `role="tablist"`, `role="tab"`, `aria-controls`, and `aria-selected`.
+
+### 15.7 Table
+
+* **Summary:** Sortable, pageable table with row actions.
+* **Endpoints:** `GET /table?page=<n>&sort=<field>:<dir>`.
+* **Events:** `greeble:table:sorted`, `greeble:table:paged`.
+* **Accessibility:** Proper table semantics, captions, and summaries.
+
+### 15.8 Toasts
+
+* **Summary:** Global toast queue using out of band swaps.
+* **Endpoints:** Any server event can return out of band toast fragments.
+* **Events:** `greeble:toast`.
+* **Accessibility:** `aria-live="assertive"` with timeouts announced.
+
+### 15.9 Command Palette
+
+* **Summary:** Input with server-backed results and keyboard selection.
+* **Endpoints:** `POST /palette/search`.
+* **Events:** `greeble:palette:select`.
+* **Accessibility:** `role="dialog"` with listbox semantics for results.
+
+### 15.10 Stepper
+
+* **Summary:** Multi-step wizard with back and next actions.
+* **Endpoints:** `GET /stepper/<step>`, `POST /stepper/<step>`.
+* **Events:** `greeble:stepper:change`.
+* **Accessibility:** Announce step changes and disabled states.
+
+### 15.11 Infinite List
+
+* **Summary:** Lazy loading list using `hx-trigger="revealed"` on a sentinel.
+* **Endpoints:** `GET /list?cursor=<id>`.
+* **Events:** `greeble:list:append`.
+* **Accessibility:** Maintain position, announce new content.
+
+### 15.12 Form with Validation Pattern
+
+* **Summary:** Server-validated form that replaces only invalid groups.
+* **Endpoints:** `POST /form/validate`, `POST /form/submit`.
+* **Events:** `greeble:form:invalid`, `greeble:form:submitted`.
+* **Accessibility:** Field-level error messages with `aria-describedby`.
+
+---
+
+## 16. Scaffolding Manifest
+
+The manifest declares the component catalog, file outputs, and contracts. The CLI consumes this file to scaffold a project or add components.
+
+```yaml
+# greeble.manifest.yaml
+version: 1
+library:
+  name: "Greeble"
+  description: "HTML-first, HTMX-powered copy and paste components for Python-first apps"
+  packages:
+    - greeble-core
+    - greeble-components
+    - greeble-hyperscript
+    - greeble-tailwind-preset
+    - greeble-django
+    - greeble-fastapi
+    - greeble-flask
+  tokens_file: "static/greeble/greeble-core.css"
+  docs_site: "docs/site"
+
+components:
+  - key: button
+    title: "Buttons"
+    summary: "Primary, secondary, icon, and split buttons"
+    files:
+      - templates/greeble/button.html
+      - static/greeble/button.css
+      - docs/components/button.md
+    endpoints: []
+    events:
+      emits: ["greeble:click"]
+      listens: []
+    accessibility:
+      notes: ["Visible focus", "aria-pressed for toggle variants"]
+
+  - key: input
+    title: "Inputs"
+    summary: "Text input, textarea, select, and combobox"
+    files:
+      - templates/greeble/input.html
+      - static/greeble/input.css
+      - docs/components/input.md
+    endpoints:
+      - method: POST
+        path: "/input/validate"
+        description: "Optional server validation for demo purposes"
+    events:
+      emits: ["greeble:validate"]
+      listens: []
+    accessibility:
+      notes: ["Labels required", "aria-describedby for help and errors"]
+
+  - key: modal
+    title: "Modal"
+    summary: "Dialog with focus trap and backdrop"
+    files:
+      - templates/greeble/modal.html
+      - templates/greeble/modal.partial.html
+      - templates/greeble/modal.hyperscript.html
+      - static/greeble/modal.css
+      - docs/components/modal.md
+    endpoints:
+      - method: GET
+        path: "/modal/example"
+        description: "Return the modal partial"
+      - method: GET
+        path: "/modal/close"
+        description: "Close the modal by clearing the root"
+      - method: POST
+        path: "/modal/submit"
+        description: "Handle form submit and return success or errors"
+    events:
+      emits: ["greeble:modal:open", "greeble:modal:close"]
+      listens: []
+    accessibility:
+      notes: ["role=dialog with aria-modal", "focus sent to panel on open"]
+
+  - key: drawer
+    title: "Drawer"
+    summary: "Edge panel for settings and filters"
+    files:
+      - templates/greeble/drawer.html
+      - templates/greeble/drawer.partial.html
+      - static/greeble/drawer.css
+      - docs/components/drawer.md
+    endpoints:
+      - method: GET
+        path: "/drawer/open"
+      - method: GET
+        path: "/drawer/close"
+    events:
+      emits: ["greeble:drawer:open", "greeble:drawer:close"]
+      listens: []
+    accessibility:
+      notes: ["role=dialog", "label with heading"]
+
+  - key: dropdown
+    title: "Dropdown Menu"
+    summary: "Button-triggered menu with keyboard navigation"
+    files:
+      - templates/greeble/dropdown.html
+      - static/greeble/dropdown.css
+      - docs/components/dropdown.md
+    endpoints: []
+    events:
+      emits: ["greeble:menu:select"]
+      listens: []
+    accessibility:
+      notes: ["role=menu with roving tabindex", "arrow key navigation"]
+
+  - key: tabs
+    title: "Tabs"
+    summary: "Tablist with per-tab content"
+    files:
+      - templates/greeble/tabs.html
+      - templates/greeble/tabs.partial.html
+      - static/greeble/tabs.css
+      - docs/components/tabs.md
+    endpoints:
+      - method: GET
+        path: "/tabs/{tabKey}"
+        description: "Return content for a given tab key"
+    events:
+      emits: ["greeble:tab:change"]
+      listens: []
+    accessibility:
+      notes: ["role=tablist and role=tab", "aria-selected and aria-controls"]
+
+  - key: table
+    title: "Table"
+    summary: "Sortable, pageable table with row actions"
+    files:
+      - templates/greeble/table.html
+      - templates/greeble/table.partial.html
+      - static/greeble/table.css
+      - docs/components/table.md
+    endpoints:
+      - method: GET
+        path: "/table"
+        description: "Accepts page and sort query parameters"
+    events:
+      emits: ["greeble:table:sorted", "greeble:table:paged"]
+      listens: []
+    accessibility:
+      notes: ["caption recommended", "scope attributes on headers"]
+
+  - key: toast
+    title: "Toasts"
+    summary: "Global toast queue using out of band swaps"
+    files:
+      - templates/greeble/toast.root.html
+      - templates/greeble/toast.item.html
+      - static/greeble/toast.css
+      - docs/components/toast.md
+    endpoints: []
+    events:
+      emits: ["greeble:toast"]
+      listens: []
+    accessibility:
+      notes: ["aria-live=assertive on root", "dismiss buttons with labels"]
+
+  - key: palette
+    title: "Command Palette"
+    summary: "Search input with server-backed results"
+    files:
+      - templates/greeble/palette.html
+      - templates/greeble/palette.partial.html
+      - static/greeble/palette.css
+      - docs/components/palette.md
+    endpoints:
+      - method: POST
+        path: "/palette/search"
+        description: "Return result list items"
+    events:
+      emits: ["greeble:palette:select"]
+      listens: []
+    accessibility:
+      notes: ["role=dialog with listbox semantics", "announce result counts"]
+
+  - key: stepper
+    title: "Stepper"
+    summary: "Multi-step wizard"
+    files:
+      - templates/greeble/stepper.html
+      - templates/greeble/stepper.partial.html
+      - static/greeble/stepper.css
+      - docs/components/stepper.md
+    endpoints:
+      - method: GET
+        path: "/stepper/{stepKey}"
+      - method: POST
+        path: "/stepper/{stepKey}"
+    events:
+      emits: ["greeble:stepper:change"]
+      listens: []
+    accessibility:
+      notes: ["announce step changes", "disable next when invalid"]
+
+  - key: infinite-list
+    title: "Infinite List"
+    summary: "Lazy loading list triggered on reveal"
+    files:
+      - templates/greeble/infinite-list.html
+      - templates/greeble/infinite-list.partial.html
+      - static/greeble/infinite-list.css
+      - docs/components/infinite-list.md
+    endpoints:
+      - method: GET
+        path: "/list"
+        description: "Accepts cursor query parameter"
+    events:
+      emits: ["greeble:list:append"]
+      listens: []
+    accessibility:
+      notes: ["maintain scroll position", "announce new content"]
+
+  - key: form-validated
+    title: "Form with Validation"
+    summary: "Server-validated form that replaces invalid groups"
+    files:
+      - templates/greeble/form.html
+      - templates/greeble/form.partial.html
+      - static/greeble/form.css
+      - docs/components/form.md
+    endpoints:
+      - method: POST
+        path: "/form/validate"
+      - method: POST
+        path: "/form/submit"
+    events:
+      emits: ["greeble:form:invalid", "greeble:form:submitted"]
+      listens: []
+    accessibility:
+      notes: ["associate errors with fields via aria-describedby"]
+```
+
+---
+
+## 17. Documentation Site Plan
+
+* Live examples for every component with a “View HTML” and “Copy” button.
+* Side-by-side snippets for Django, FastAPI, and Flask endpoints.
+* Patterns section: CRUD with HTMX, streaming updates, pagination and sorting, and validation flows.
+* Accessibility checklists per component.
+
+---
+
+## 18. Roadmap
+
+* 0.1: Buttons, Inputs, Modal, Toasts, Table, Dropdown Menu.
+* 0.2: Tabs, Drawer, Stepper, Infinite List.
+* 0.3: Command Palette, Combobox improvements, Tree View.
+* 0.4: File Upload pattern, Data Grid enhancements, Date Picker.
+
+---
+
+## 19. Open Questions
+
+* Should the library ship optional Alpine.js shims for teams who prefer it over Hyperscript, or should that remain an external recipe.
+* How strict should the adapters be about differentiating HTMX requests from normal submits when deciding which template to render.
+* What level of configurability is needed for keyboard bindings in the command palette and menu components.
+
+---
+
+## 20. Appendix: Minimal FastAPI Example
+
+```python
+from fastapi import FastAPI, Request, Form
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+app = FastAPI()
+templates = Jinja2Templates("templates")
+
+@app.get("/", response_class=HTMLResponse)
+def home(request: Request):
+    return templates.TemplateResponse("home.html", {"request": request})
+
+@app.get("/modal/example", response_class=HTMLResponse)
+def modal_example(request: Request):
+    return templates.TemplateResponse("greeble/modal.partial.html", {"request": request})
+
+@app.get("/modal/close", response_class=HTMLResponse)
+def modal_close():
+    return HTMLResponse("")
+
+@app.post("/modal/submit", response_class=HTMLResponse)
+def modal_submit(request: Request, email: str = Form(...)):
+    html = f"""
+    <div id=\"greeble-toasts\" hx-swap-oob=\"true\">
+      <div class=\"greeble-toast greeble-toast--success\">Saved {email}</div>
+    </div>
+    """
+    return HTMLResponse(html)
+```
+
+---
+
+## 21. Appendix: Token Starter
+
+```css
+:root {
+  --greeble-color-background: #0b0b0c;
+  --greeble-color-foreground: #e8e8ea;
+  --greeble-color-muted: #a0a0a7;
+  --greeble-color-accent: #6aa1ff;
+  --greeble-radius-medium: 12px;
+  --greeble-shadow-1: 0 1px 2px rgba(0,0,0,.2);
+  --greeble-shadow-2: 0 8px 30px rgba(0,0,0,.35);
+  --greeble-spacing-1: .25rem;
+  --greeble-spacing-2: .5rem;
+  --greeble-spacing-3: .75rem;
+  --greeble-spacing-4: 1rem;
+  --greeble-focus-ring: 0 0 0 3px rgba(106,161,255,.5);
+}
+
+.greeble-button { padding: var(--greeble-spacing-2) var(--greeble-spacing-4); border-radius: var(--greeble-radius-medium); box-shadow: var(--greeble-shadow-1); }
+.greeble-button--accent { background: var(--greeble-color-accent); color: #0b0b0c; }
+.greeble-input { background: #151518; color: var(--greeble-color-foreground); border: 1px solid #2a2a32; padding: var(--greeble-spacing-2) var(--greeble-spacing-3); border-radius: 10px; }
+.greeble-modal { position: fixed; inset: 0; display: grid; place-items: center; }
+.greeble-modal__backdrop { position: absolute; inset: 0; background: rgba(0,0,0,.5); }
+.greeble-modal__panel { position: relative; background: #101014; color: var(--greeble-color-foreground); border-radius: var(--greeble-radius-medium); padding: var(--greeble-spacing-4); box-shadow: var(--greeble-shadow-2); }
+.greeble-icon-button:focus-visible { outline: none; box-shadow: var(--greeble-focus-ring); }
+.visually-hidden { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "greeble"
-version = "0.1.0"
+version = "0.0.3"
 description = "HTML-first component library that delivers copy and paste snippets powered by HTMX for rapid UI construction"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -71,4 +71,12 @@ disallow_untyped_defs = true
 addopts = "-q"
 testpaths = ["tests"]
 asyncio_mode = "auto"
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+# Read version from [project] (PEP 621) so a single source of truth is used.
+version_provider = "pep621"
+tag_format = "v$version"
+update_changelog_on_bump = true
+changelog_file = "CHANGELOG.md"
 

--- a/src/greeble/scripts/dev.py
+++ b/src/greeble/scripts/dev.py
@@ -11,6 +11,11 @@ Subcommands:
   - test       -> pytest -q
   - build      -> uv build
   - check      -> ruff check (--fix locally) + ruff format . + mypy . + pytest -q
+  - version    -> dev version [current|bump <major|minor|patch>]
+  - release    -> dev release rc  (create and push the release-candidate branch)
+  - branch-finalize -> merge the current branch into release-candidate and push
+  - release-pr -> open a PR from release-candidate to main (uses latest CHANGELOG)
+  - protect-main -> attempt to enable branch protection via gh CLI
 
 Pass-through args after the subcommand are forwarded to the underlying tool.
 """
@@ -19,8 +24,14 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 import sys
+from collections.abc import Iterable, Sequence
+from contextlib import suppress
+from datetime import date
+from pathlib import Path
+from typing import Literal, cast
 
 
 def is_ci() -> bool:
@@ -53,6 +64,11 @@ def main(argv: list[str] | None = None) -> int:
             "test",
             "build",
             "check",
+            "version",
+            "release",
+            "branch-finalize",
+            "release-pr",
+            "protect-main",
         ],
         help="task to run",
     )
@@ -104,6 +120,16 @@ def main(argv: list[str] | None = None) -> int:
             if (rc := run(["ruff", "format", "."])) != 0:
                 return rc
             return run_mypy_then_pytest_quiet()
+        case "version":
+            return handle_version(passthrough)
+        case "release":
+            return handle_release(passthrough)
+        case "branch-finalize":
+            return handle_branch_finalize()
+        case "release-pr":
+            return handle_release_pr()
+        case "protect-main":
+            return handle_protect_main()
     parser.error("unknown subcommand")
     return 2
 
@@ -121,6 +147,474 @@ def run_mypy_then_pytest_quiet() -> int:
         return rc
     rc = run(["pytest", "-q"]) or 0
     return 0 if rc in (0, 5) else rc
+
+
+# --- Versioning & Release helpers -------------------------------------------------
+
+VersionPart = Literal["major", "minor", "patch"]
+
+
+def handle_version(args: Sequence[str]) -> int:
+    """`dev version [current|bump <major|minor|patch>]`
+
+    - `current`: prints the current version to stdout
+    - `bump <part>`: increments version in pyproject.toml, updates CHANGELOG.md from
+      conventional commits since last tag, creates a release commit and an annotated tag.
+    """
+    cmd = args[0] if args else "current"
+    if cmd not in {"current", "bump"}:
+        sys.stderr.write("usage: dev version [current|bump <major|minor|patch>]\n")
+        return 2
+
+    root = find_project_root()
+    pyproject = root / "pyproject.toml"
+    if cmd == "current":
+        print(read_project_version(pyproject))
+        return 0
+
+    # bump flow
+    part: VersionPart = "patch"
+    if len(args) >= 2:
+        part_arg = args[1].lower()
+        if part_arg not in {"major", "minor", "patch"}:
+            sys.stderr.write("error: part must be one of: major, minor, patch\n")
+            return 2
+        part = cast(VersionPart, part_arg)
+
+    current_version = read_project_version(pyproject)
+    new_version = bump_version(current_version, part)
+
+    # Update pyproject.toml
+    write_project_version(pyproject, new_version)
+
+    # Update CHANGELOG.md
+    changelog = root / "CHANGELOG.md"
+    prev_tag = f"v{current_version}"
+    entries = collect_conventional_commits(prev_tag)
+    prepend_changelog(changelog, new_version, entries)
+
+    # Commit and tag
+    git(["add", str(pyproject), str(changelog)])
+    # Use --no-verify to avoid pre-commit failing the release commit if it reformats files
+    git(["commit", "--no-verify", "-m", f"chore(release): v{new_version}"])
+    git(["tag", "-a", f"v{new_version}", "-m", f"Release v{new_version}"])
+    print(f"Bumped version: {current_version} -> {new_version}")
+    print(f"Created tag v{new_version}. Push with: git push && git push --tags")
+    return 0
+
+
+def handle_protect_main() -> int:
+    """Attempt to protect the `main` branch using GitHub CLI, or print instructions."""
+    # Try to detect owner/repo from git and use gh if available.
+    try:
+        origin = git(["config", "--get", "remote.origin.url"], capture_output=True)
+        owner_repo = parse_owner_repo(origin.strip())
+        if not owner_repo:
+            raise RuntimeError("Could not parse owner/repo from remote.origin.url")
+        if shutil_which("gh") is None:
+            raise RuntimeError("gh CLI not found")
+        owner, repo = owner_repo
+        payload = (
+            "{\n"
+            '  "enforce_admins": true,\n'
+            '  "required_status_checks": null,\n'
+            '  "required_pull_request_reviews": {\n'
+            '    "required_approving_review_count": 1\n'
+            "  },\n"
+            '  "restrictions": null\n'
+            "}"
+        )
+        gh_cmd = [
+            "gh",
+            "api",
+            "-X",
+            "PUT",
+            f"repos/{owner}/{repo}/branches/main/protection",
+            "-H",
+            "Accept: application/vnd.github+json",
+            "--input",
+            "-",
+        ]
+        # Feed JSON via stdin
+        proc = subprocess.run(gh_cmd, input=payload.encode(), check=False)
+        if proc.returncode == 0:
+            print("Branch protection for main configured via gh CLI.")
+            return 0
+        else:
+            raise RuntimeError("gh api command failed")
+    except Exception as e:  # noqa: BLE001 - we want a friendly message
+        print(
+            (
+                "Could not configure branch protection automatically.\n"
+                "To enable manually, run:\n"
+                "  gh api -X PUT repos/<owner>/<repo>/branches/main/protection \\\n"
+                "    -H 'Accept: application/vnd.github+json' \\\n"
+                "    --input - <<'JSON'\n"
+                "{\n"
+                '  "enforce_admins": true,\n'
+                '  "required_status_checks": null,\n'
+                '  "required_pull_request_reviews": {\n'
+                '    "required_approving_review_count": 1\n'
+                "  },\n"
+                '  "restrictions": null\n'
+                "}\n"
+                "JSON\n"
+            )
+            + (f"Reason: {e}\n")
+        )
+        return 1
+
+
+def shutil_which(
+    name: str,
+) -> str | None:
+    from shutil import which
+
+    return which(name)
+
+
+def handle_release(args: Sequence[str]) -> int:
+    """`dev release rc` creates and pushes the `release-candidate` branch.
+
+    Intended workflow:
+    - Create `release-candidate`
+    - Merge feature branches into `release-candidate`
+    - When ready, merge `release-candidate` into `main` and bump version
+    """
+    if not args or args[0] != "rc":
+        sys.stderr.write("usage: dev release rc\n")
+        return 2
+    # Ensure working tree clean, or proceed? We'll proceed but git may block.
+    branch = "release-candidate"
+    git(["checkout", "-B", branch])
+    # Push and set upstream
+    try:
+        git(["push", "-u", "origin", branch])
+    except subprocess.CalledProcessError:
+        # Origin may not be set; print next steps
+        print("Created local branch 'release-candidate'. Set up a remote and push when ready.")
+        return 0
+    print("Release candidate branch created and pushed: release-candidate")
+    return 0
+
+
+def handle_branch_finalize() -> int:
+    """Merge the current branch into 'release-candidate' and push.
+
+    - Detect the current branch (must not be 'release-candidate').
+    - Checkout 'release-candidate' based on (in order): origin/release-candidate, origin/main, main.
+    - Merge the current branch with a no-fast-forward merge.
+    - Push 'release-candidate' (creates upstream if needed).
+    - Switch back to the original branch on success.
+    """
+    try:
+        current = git(["rev-parse", "--abbrev-ref", "HEAD"], capture_output=True)
+    except subprocess.CalledProcessError:
+        sys.stderr.write("error: not a git repository or cannot determine current branch\n")
+        return 2
+    current = current.strip()
+    if current == "release-candidate":
+        sys.stderr.write(
+            "error: you're already on 'release-candidate'. Run this from a feature branch.\n"
+        )
+        return 2
+
+    # Try to fetch remotes to get latest refs
+    with suppress(subprocess.CalledProcessError):
+        git(["fetch", "--all"])
+
+    # Checkout release-candidate with sensible base
+    if not checkout_release_candidate_with_base():
+        sys.stderr.write(
+            "error: could not checkout 'release-candidate'. "
+            "Ensure 'main' exists locally or on origin.\n"
+        )
+        return 2
+
+    # Merge current branch
+    try:
+        git(["merge", "--no-ff", current])
+    except subprocess.CalledProcessError:
+        print(
+            "Merge conflicts detected while merging into 'release-candidate'.\n"
+            "Resolve conflicts, commit the merge, then push with:\n"
+            "  git push -u origin release-candidate\n"
+        )
+        return 1
+
+    # Push RC
+    try:
+        git(["push", "-u", "origin", "release-candidate"])
+        pushed = True
+    except subprocess.CalledProcessError:
+        pushed = False
+        print(
+            "Could not push 'release-candidate' automatically. Push manually with:\n"
+            "  git push -u origin release-candidate\n"
+        )
+
+    # Switch back to original branch
+    with suppress(subprocess.CalledProcessError):
+        # stay on RC if we cannot switch back
+        git(["checkout", current])
+
+    if pushed:
+        print("Merged current branch into 'release-candidate' and pushed upstream.")
+        return 0
+    print("Merged current branch into 'release-candidate'. Not pushed.")
+    return 0
+
+
+def checkout_release_candidate_with_base() -> bool:
+    """Checkout 'release-candidate' creating/updating it from the best available base."""
+    bases = [
+        "origin/release-candidate",
+        "origin/main",
+        "main",
+    ]
+    for base in bases:
+        try:
+            git(["checkout", "-B", "release-candidate", base])
+            return True
+        except subprocess.CalledProcessError:
+            continue
+    # Last resort: try to just create the branch if no base is available
+    try:
+        git(["checkout", "-B", "release-candidate"])  # detached from any base
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def handle_release_pr() -> int:
+    """Open a GitHub PR from release-candidate to main using the latest changelog.
+
+    Requires the GitHub CLI (gh). The PR title will default to "Release vX.Y.Z" if the
+    latest CHANGELOG section header is of the form `## [X.Y.Z] - YYYY-MM-DD`, otherwise
+    it will be "Release candidate to main". The PR body will be the content of the
+    latest section.
+    """
+    if shutil_which("gh") is None:
+        print(
+            "GitHub CLI (gh) not found. Install from https://cli.github.com/ and run:\n"
+            "  gh auth login\n"
+            "Then re-run: uv run dev release-pr\n"
+        )
+        return 2
+
+    # Ensure release-candidate exists locally
+    with suppress(subprocess.CalledProcessError):
+        git(["fetch", "--all"])
+    try:
+        git(["rev-parse", "--verify", "release-candidate"], capture_output=True)
+    except subprocess.CalledProcessError:
+        sys.stderr.write(
+            "error: 'release-candidate' branch not found. Create it first with "
+            "'uv run dev release rc' or 'uv run dev branch-finalize'.\n"
+        )
+        return 2
+
+    root = find_project_root()
+    changelog_path = root / "CHANGELOG.md"
+    version, section_body = parse_changelog_latest_section(changelog_path)
+    title = f"Release v{version}" if version else "Release candidate to main"
+    body = section_body or "(No changelog entries found)"
+
+    # Create PR with gh
+    cmd = [
+        "gh",
+        "pr",
+        "create",
+        "--base",
+        "main",
+        "--head",
+        "release-candidate",
+        "--title",
+        title,
+        "--body",
+        body,
+    ]
+    proc = subprocess.run(cmd, check=False)
+    if proc.returncode == 0:
+        print("Opened pull request from release-candidate to main.")
+        return 0
+    print("Failed to open pull request via gh CLI. Ensure you are authenticated.")
+    return 1
+
+
+def parse_changelog_latest_section(
+    changelog_path: Path,
+) -> tuple[str | None, str]:
+    """Return (version, section_body) for the latest changelog section.
+
+    The expected header format is: `## [X.Y.Z] - YYYY-MM-DD`.
+    If the file or header is missing, returns (None, "").
+    """
+    if not changelog_path.exists():
+        return None, ""
+    lines = changelog_path.read_text(encoding="utf-8").splitlines()
+    header_re = re.compile(r"^## \[(?P<ver>\d+\.\d+\.\d+)\] - ")
+    version: str | None = None
+    start_idx: int | None = None
+    end_idx: int | None = None
+    for i, line in enumerate(lines):
+        m = header_re.match(line.strip())
+        if m:
+            if start_idx is None:
+                start_idx = i
+                version = m.group("ver")
+            elif end_idx is None:
+                end_idx = i
+                break
+    if start_idx is None:
+        return None, ""
+    if end_idx is None:
+        end_idx = len(lines)
+    # Section body excludes the header and ends before next section header
+    body_lines = lines[start_idx + 1 : end_idx]
+    # Trim leading blank lines
+    while body_lines and not body_lines[0].strip():
+        body_lines.pop(0)
+    # Keep body as markdown
+    return version, "\n".join(body_lines).strip()
+
+
+def find_project_root() -> Path:
+    """Find the project root containing a pyproject.toml."""
+    cur = Path.cwd()
+    for p in [cur, *cur.parents]:
+        if (p / "pyproject.toml").exists():
+            return p
+    raise FileNotFoundError("pyproject.toml not found in current directory or parents")
+
+
+def read_project_version(pyproject_path: Path) -> str:
+    import tomllib
+
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    version = data.get("project", {}).get("version")
+    if not isinstance(version, str):
+        raise ValueError("project.version not found or invalid in pyproject.toml")
+    return version
+
+
+def write_project_version(pyproject_path: Path, new_version: str) -> None:
+    content = pyproject_path.read_text(encoding="utf-8")
+
+    # Replace the first occurrence of version = "..." under [project]
+    # Simple, assumes a single project.version key.
+    def _repl(m: re.Match[str]) -> str:
+        return f'{m.group(1)}"{new_version}"'
+
+    new_content, n = re.subn(r"(?m)^(version\s*=\s*)\"[^\"]+\"", _repl, content)
+    if n == 0:
+        raise ValueError("Could not update version in pyproject.toml")
+    pyproject_path.write_text(new_content, encoding="utf-8")
+
+
+def bump_version(version: str, part: VersionPart) -> str:
+    try:
+        major_s, minor_s, patch_s = version.split(".")
+        major, minor, patch = int(major_s), int(minor_s), int(patch_s)
+    except Exception as e:  # noqa: BLE001
+        raise ValueError(f"invalid version: {version}") from e
+    if part == "major":
+        return f"{major + 1}.0.0"
+    if part == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def git(args: Sequence[str], *, capture_output: bool = False) -> str:
+    cmd = ["git", *args]
+    if capture_output:
+        return subprocess.check_output(cmd).decode().strip()
+    subprocess.check_call(cmd)
+    return ""
+
+
+def collect_conventional_commits(since_tag: str | None) -> list[tuple[str, str, str]]:
+    """Return list of (type, subject, short_sha) since a tag (or from start)."""
+    fmt = "%h\t%s"
+    range_spec = f"{since_tag}..HEAD" if since_tag and tag_exists(since_tag) else None
+    log_cmd = ["log", "--pretty=format:" + fmt, "--no-merges"]
+    if range_spec:
+        log_cmd.append(range_spec)
+    out = git(log_cmd, capture_output=True)
+    entries: list[tuple[str, str, str]] = []
+    cc_re = re.compile(
+        r"^(?P<type>feat|fix|perf|refactor|docs|build|ci|test|chore|revert)"
+        r"(?:\([^)]*\))?(?:!)?:\s*(?P<subject>.+)"
+    )
+    for line in out.splitlines():
+        try:
+            sha, subject = line.split("\t", 1)
+        except ValueError:
+            continue
+        m = cc_re.match(subject)
+        ctype = m.group("type") if m else "other"
+        csubject = m.group("subject") if m else subject
+        entries.append((ctype, csubject, sha))
+    return entries
+
+
+def tag_exists(tag: str) -> bool:
+    try:
+        out = git(["tag", "-l", tag], capture_output=True)
+        return any(line.strip() == tag for line in out.splitlines())
+    except subprocess.CalledProcessError:
+        return False
+
+
+def prepend_changelog(
+    changelog_path: Path,
+    new_version: str,
+    entries: Iterable[tuple[str, str, str]],
+) -> None:
+    today = date.today().isoformat()
+    header = f"## [{new_version}] - {today}\n\n"
+    if not entries:
+        body = "- No user-facing changes\n\n"
+    else:
+        # Group by type but keep chronological order
+        type_order = [
+            "feat",
+            "fix",
+            "perf",
+            "refactor",
+            "docs",
+            "build",
+            "ci",
+            "test",
+            "chore",
+            "revert",
+            "other",
+        ]
+        lines: list[str] = []
+        for ctype in type_order:
+            group = [(t, s, h) for (t, s, h) in entries if t == ctype]
+            if not group:
+                continue
+            lines.append(f"### {ctype}")
+            lines.extend([f"- {s} ({h})" for (_, s, h) in group])
+            lines.append("")
+        body = "\n".join(lines) + "\n"
+    if changelog_path.exists():
+        prev = changelog_path.read_text(encoding="utf-8")
+    else:
+        prev = "# Changelog\n\n"
+    # Prepend new release notes so the latest version appears at the top
+    new_content = header + body + prev
+    changelog_path.write_text(new_content, encoding="utf-8")
+
+
+def parse_owner_repo(remote_url: str) -> tuple[str, str] | None:
+    # Support SSH and HTTPS
+    # git@github.com:owner/repo.git or https://github.com/owner/repo.git
+    m = re.search(r"github.com[:/](?P<owner>[^/]+)/(?P<repo>[^/.]+)", remote_url)
+    if not m:
+        return None
+    return m.group("owner"), m.group("repo")
 
 
 def lint_main() -> int:

--- a/uv.lock
+++ b/uv.lock
@@ -104,7 +104,7 @@ wheels = [
 
 [[package]]
 name = "greeble"
-version = "0.1.0"
+version = "0.0.3"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
### feat
- semantic versioning + release helpers; centralize tool configs; set initial version 0.0.1\n\n- dev version current|bump <major|minor|patch> with CHANGELOG generation and annotated tags\n- dev release rc to create/push release-candidate\n- dev protect-main uses gh CLI to enable branch protection\n- Commitizen pre-commit commit-msg hook enforcing Conventional Commits\n- Configs in pyproject (ruff, mypy, pytest, commitizen)\n- Docs version set to 0.0.1 (6072fed)

### refactor
- modernize dev CLI and wire up uv entry point\n\n- Replace if-chain with match-case; add is_ci() and run_mypy_then()\n- Improve typing and docstrings; simplify ruff checks\n- Update wrapper entrypoints to call local main()\n- Add build-system (hatchling) and src/ layout packaging config\n- Configure [project.scripts] dev entry point; default dev dependency group via [tool.uv]\n- Add package __init__.py\n\nRun with: uv run dev --help (5875223)

### ci
- add GitHub Actions workflow; update pre-commit stages; make dev check treat no-tests (pytest rc=5) as success (9066908)

### chore
- centralize tool configs in pyproject (ruff, mypy, pytest); add return type to main() (65d5948)
- remove stale erasmus entrypoint and add pre-commit hook to run 'uv run dev check' (2963923)

### other
- Initial commit (fcbcabd)