### PR TITLE
feat(hyperscript): wire modal hyperscript and include runtime in starter

### DIFF
--- a/src/greeble_cli/templates/starter/index.html
+++ b/src/greeble_cli/templates/starter/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="/static/greeble/greeble-core.css" />
     <link rel="stylesheet" href="/static/site.css" />
     <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
+    <script src="https://unpkg.com/hyperscript.org@0.9.12"></script>
   </head>
   <body>
     <header class="site-header">

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,8 @@ def test_cli_add_component_custom_docs(tmp_path: Path) -> None:
     assert exit_code == 0
     assert (project_root / "templates" / "greeble" / "modal.html").exists()
     assert (project_root / "documentation" / "components" / "modal.md").exists()
+    # Hyperscript snippet should be included for modal
+    assert (project_root / "templates" / "greeble" / "modal.hyperscript.html").exists()
 
 
 def test_cli_add_nonexistent_component(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -156,6 +158,9 @@ def test_cli_new_starter(tmp_path: Path) -> None:
     assert modal_template.exists()
     modal_partial = project_root / "templates" / "greeble" / "modal.partial.html"
     assert modal_partial.exists()
+    # Hyperscript snippet should be present in starter assets as well
+    modal_hyperscript = project_root / "templates" / "greeble" / "modal.hyperscript.html"
+    assert modal_hyperscript.exists()
 
     docs_path = project_root / "docs" / "components" / "modal.md"
     assert docs_path.exists()


### PR DESCRIPTION
This PR wires Hyperscript into the starter and component scaffold flows.\n\nChanges:\n- Starter HTML now includes the Hyperscript runtime (via unpkg).\n- Manifest includes modal.hyperscript.html so  and  copy it.\n- Tests updated to assert hyperscript file is present when adding modal and in the starter.\n\nValidation:\n- All checks passed!
75 files left unchanged
Success: no issues found in 61 source files
........................................................................ [ 98%]
.                                                                        [100%]
=============================== warnings summary ===============================
tests/components/test_inputs_fastapi_e2e.py::test_inputs_render
tests/components/test_tabs_fastapi_e2e.py::test_tabs_home_renders
  /repos/webdev/greeble/.venv/lib/python3.13/site-packages/starlette/templating.py:162: DeprecationWarning: The `name` is not the first parameter anymore. The first parameter should be the `Request` instance.
  Replace `TemplateResponse(name, {"request": request})` by `TemplateResponse(request, name)`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html passes.\n\nFollow-ups:\n- When additional components ship hyperscript snippets, add them to the manifest to include automatically.\n- Optionally gate the Hyperscript runtime behind a CLI flag or per-component opt-in if desired.}