### PR TITLE
feat(starter): src layout with greeble_starter package

### DIFF
--- a/src/greeble_cli/starter.py
+++ b/src/greeble_cli/starter.py
@@ -32,6 +32,7 @@ STARTER_STATIC_FILES = {
 STARTER_APP_FILES = {
     "src/greeble_starter/app.py": "app_main.py",
     "src/greeble_starter/__init__.py": "package_init.py",
+    "src/greeble_starter/__main__.py": "package_dunder_main.py",
 }
 
 STARTER_ROOT_FILES = {

--- a/src/greeble_cli/starter.py
+++ b/src/greeble_cli/starter.py
@@ -30,7 +30,8 @@ STARTER_STATIC_FILES = {
 }
 
 STARTER_APP_FILES = {
-    "app/main.py": "app_main.py",
+    "src/greeble_starter/app.py": "app_main.py",
+    "src/greeble_starter/__init__.py": "package_init.py",
 }
 
 STARTER_ROOT_FILES = {

--- a/src/greeble_cli/templates/starter/app_main.py
+++ b/src/greeble_cli/templates/starter/app_main.py
@@ -27,7 +27,8 @@ from greeble.demo import (
 )
 from greeble.demo.helpers import ProductLike
 
-BASE_DIR = Path(__file__).resolve().parent.parent
+# Project root when this file is located at src/greeble_starter/app.py
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 TEMPLATES = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 app = FastAPI(title="Greeble Starter")
 app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")

--- a/src/greeble_cli/templates/starter/package_dunder_main.py
+++ b/src/greeble_cli/templates/starter/package_dunder_main.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import uvicorn
+
+
+def main() -> None:
+    """Console entry point for the Greeble Starter app.
+
+    Runs the FastAPI app with uvicorn in reload mode by default.
+    """
+    uvicorn.run("greeble_starter.app:app", reload=True)

--- a/src/greeble_cli/templates/starter/package_init.py
+++ b/src/greeble_cli/templates/starter/package_init.py
@@ -1,0 +1,8 @@
+"""Greeble Starter package.
+
+This package contains the FastAPI app and uses a src/ layout.
+"""
+
+__all__ = [
+    # exported names can be added here if needed
+]

--- a/src/greeble_cli/templates/starter/starter_README.md
+++ b/src/greeble_cli/templates/starter/starter_README.md
@@ -6,7 +6,11 @@ v0.1 components so you can explore HTMX flows end-to-end.
 ## Getting started
 
 ```bash
-uv run uvicorn greeble_starter.app:app --reload
+# Option A: console script
+uv run greeble-starter
+
+# Option B: module invocation
+uv run python -m greeble_starter
 ```
 
 Open http://127.0.0.1:8050/ to interact with the demo endpoints.

--- a/src/greeble_cli/templates/starter/starter_README.md
+++ b/src/greeble_cli/templates/starter/starter_README.md
@@ -6,15 +6,15 @@ v0.1 components so you can explore HTMX flows end-to-end.
 ## Getting started
 
 ```bash
-uv run uvicorn app.main:app --reload
+uv run uvicorn greeble_starter.app:app --reload
 ```
 
 Open http://127.0.0.1:8050/ to interact with the demo endpoints.
 
 ## Structure
 
-- `app/main.py` – FastAPI application exposing modal, drawer, table, palette, tabs, form, stepper,
-  and infinite list endpoints
+- `src/greeble_starter/app.py` – FastAPI application exposing modal, drawer, table, palette, tabs,
+  form, stepper, and infinite list endpoints
 - `templates/` – Base layout (`index.html`) and component templates copied from Greeble
 - `static/` – Core tokens (`greeble-core.css` copied via CLI) and a small site stylesheet
 

--- a/src/greeble_cli/templates/starter/starter_pyproject.toml
+++ b/src/greeble_cli/templates/starter/starter_pyproject.toml
@@ -15,8 +15,11 @@ dependencies = [
 dev = ["pytest>=8.4.2", "ruff>=0.13.1"]
 
 [project.scripts]
-start = "uvicorn app.main:app --reload"
+start = "uvicorn greeble_starter.app:app --reload"
 
 [build-system]
 requires = ["hatchling>=1.25"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/greeble_starter"]

--- a/src/greeble_cli/templates/starter/starter_pyproject.toml
+++ b/src/greeble_cli/templates/starter/starter_pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 dev = ["pytest>=8.4.2", "ruff>=0.13.1"]
 
 [project.scripts]
-start = "uvicorn greeble_starter.app:app --reload"
+greeble-starter = "greeble_starter.__main__:main"
 
 [build-system]
 requires = ["hatchling>=1.25"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,7 +148,7 @@ def test_cli_new_starter(tmp_path: Path) -> None:
     exit_code = main(["new", str(project_root), "--include-docs"])
     assert exit_code == 0
 
-    starter_main = project_root / "app" / "main.py"
+    starter_main = project_root / "src" / "greeble_starter" / "app.py"
     assert starter_main.exists()
     content = starter_main.read_text(encoding="utf-8")
     assert "FastAPI" in content


### PR DESCRIPTION
This updates the starter scaffold to use a src/ layout with a greeble_starter package so Hatch can build the project cleanly.\n\nChanges:\n- Scaffold app under src/greeble_starter/app.py with __init__.py.\n- Adjust starter pyproject: hatch packages and new uvicorn entry point.\n- Update README and app BASE_DIR for src layout.\n- Update tests to expect src/greeble_starter/app.py.\n\nValidation:\n- dev check passes.\n- CLI tests updated for new paths.\n\nThis should fix uv build errors for starters (default Hatch selection).}

## Summary by Sourcery

Reorganize the starter scaffold into a src/ greeble_starter package, update build and entrypoint configuration, and align documentation and tests with the new layout.

New Features:
- Scaffold starter template under a src/greeble_starter package with __init__.py

Enhancements:
- Configure Hatch build targets to package src/greeble_starter and update the default uvicorn entrypoint

Documentation:
- Update starter README to reference greeble_starter.app and the new src layout

Tests:
- Adjust CLI tests to expect the app at src/greeble_starter/app.py