### PR TITLE
feat(starter): console entrypoint flags and 8050 default

### DIFF
--- a/src/greeble_cli/templates/starter/package_dunder_main.py
+++ b/src/greeble_cli/templates/starter/package_dunder_main.py
@@ -1,11 +1,45 @@
 from __future__ import annotations
 
+import argparse
+
 import uvicorn
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     """Console entry point for the Greeble Starter app.
 
-    Runs the FastAPI app with uvicorn in reload mode by default.
+    Defaults: host 127.0.0.1, port 8050, reload on.
     """
-    uvicorn.run("greeble_starter.app:app", reload=True)
+    parser = argparse.ArgumentParser(
+        prog="greeble-starter", description="Run the Greeble Starter app"
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=8050, help="Port (default: 8050)")
+    parser.add_argument(
+        "--reload",
+        dest="reload",
+        action="store_true",
+        default=True,
+        help="Enable auto-reload (default)",
+    )
+    parser.add_argument(
+        "--no-reload",
+        dest="reload",
+        action="store_false",
+        help="Disable auto-reload",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="info",
+        choices=["critical", "error", "warning", "info", "debug", "trace"],
+        help="Uvicorn log level (default: info)",
+    )
+    args = parser.parse_args(argv)
+
+    uvicorn.run(
+        "greeble_starter.app:app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+        log_level=args.log_level,
+    )


### PR DESCRIPTION
Adds argparse to the starter console entrypoint:\n- Flags: --host, --port (default 8050), --[no-]reload, --log-level.\n- Aligns README guidance and avoids accidentally launching when requesting help.\n\nValidation: dev check passes.

## Summary by Sourcery

Introduce argparse-based configuration flags to the Greeble Starter console entrypoint, enabling host, port (default 8050), reload behavior, and log-level customization.

New Features:
- Add argparse-based CLI flags (--host, --port, --reload/--no-reload, --log-level) to the starter console entrypoint
- Set the default port to 8050

Enhancements:
- Allow passing an optional argv parameter to the main function for easier testing and invocation