### PR TITLE
feat(starter,docs): minimal landing + docs copy buttons

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -17,6 +17,12 @@
 - Use `HX-Trigger` headers in the response to emit `greeble:click` (or any custom event) so other
   components can react.
 
+## Include in template
+
+```jinja
+{% include "greeble/button.html" %}
+```
+
 ## Copy & Paste
 
 ```html

--- a/docs/components/drawer.md
+++ b/docs/components/drawer.md
@@ -17,6 +17,12 @@
 
 ## Copy & Paste
 
+## Include in template
+
+```jinja
+{% include "greeble/drawer.html" %}
+```
+
 ```html
 <div class="greeble-drawer-trigger">
   <button class="greeble-button greeble-button--primary" type="button"

--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -10,6 +10,12 @@
 - Theming hooks: `.greeble-dropdown__panel`, `.greeble-dropdown__item`, `.greeble-dropdown__chevron`,
   and `.greeble-dropdown__item-kbd` can all be themed via CSS or tokens.
 
+## Include in template
+
+```jinja
+{% include "greeble/dropdown.html" %}
+```
+
 ## Copy & Paste
 
 ```html

--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -11,6 +11,12 @@
 - Theming hooks: `.greeble-validated-form__body`, `.greeble-field--invalid`, and
   `.greeble-validated-form__actions`.
 
+## Include in template
+
+```jinja
+{% include "greeble/form.html" %}
+```
+
 ## Copy & Paste
 
 ```html

--- a/docs/components/infinite-list.md
+++ b/docs/components/infinite-list.md
@@ -11,6 +11,12 @@
   `<strong>` headings, descriptive copy). Provide manual controls in addition to the sentinel.
 - Theming hooks: `.greeble-feed__item`, `.greeble-feed__sentinel`, and `.greeble-feed__description`.
 
+## Include in template
+
+```jinja
+{% include "greeble/infinite-list.html" %}
+```
+
 ## Copy & Paste
 
 ```html

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -19,6 +19,12 @@
 - Full form submissions typically respond with out-of-band toasts and a fresh input group to clear
   the field.
 
+## Include in template
+
+```jinja
+{% include "greeble/input.html" %}
+```
+
 ## Copy & Paste
 
 ```html

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -17,6 +17,12 @@
   toast to close the dialog and inform the user. On validation failure, return the modal partial
   with inline errors and set the status to 400 so HTMX keeps the dialog mounted.
 
+## Include in template
+
+```jinja
+{% include "greeble/modal.html" %}
+```
+
 ## Copy & Paste
 
 ```html

--- a/docs/components/palette.md
+++ b/docs/components/palette.md
@@ -11,6 +11,12 @@
 - Theming hooks: `.greeble-palette__result`, `.greeble-palette__detail`, `.greeble-palette__layout`,
   and `.greeble-palette__form` expose layout and colour customisation points.
 
+## Include in template
+
+```jinja
+{% include "greeble/palette.html" %}
+```
+
 ## Copy & Paste
 
 ```html

--- a/docs/components/stepper.md
+++ b/docs/components/stepper.md
@@ -11,6 +11,12 @@
 - Theming hooks: `.greeble-stepper__badge`, `.greeble-stepper__step[aria-current]`, and
   `.greeble-stepper__panel`.
 
+## Include in template
+
+```jinja
+{% include "greeble/stepper.html" %}
+```
+
 ## Copy & Paste
 
 ```html

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -13,6 +13,12 @@
   actions, and `greeble:toast` when exports queue background jobs.
 - Theming hooks: Override `.greeble-table__status--*` colors or container background to match brand palette.
 
+## Include in template
+
+```jinja
+{% include "greeble/table.html" %}
+```
+
 ## Copy & Paste
 
 ```html

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -11,6 +11,12 @@
 - Theming hooks: `.greeble-tabs__tab`, `.greeble-tabs__tab[aria-selected="true"]`, and
   `.greeble-tabs__panel`.
 
+## Include in template
+
+```jinja
+{% include "greeble/tabs.html" %}
+```
+
 ## Copy & Paste
 
 ```html

--- a/docs/components/toast.md
+++ b/docs/components/toast.md
@@ -7,6 +7,13 @@
 - Accessibility: Each toast is `role="status"`; dismiss buttons include `aria-label`; icons are decorative `aria-hidden`.
 - Theming hooks: Override custom properties (`--_toast-*`) or variant colors to match brand guidelines.
 
+## Include in template
+
+```jinja
+{% include "greeble/toast.root.html" %}
+{% include "greeble/toast.item.html" %}
+```
+
 ## Server contract
 
 - Any endpoint can return a toast out-of-band by wrapping the item markup in a `<div id="greeble-toasts" hx-swap-oob="true">…</div>` container.

--- a/src/greeble_cli/templates/starter/app_main.py
+++ b/src/greeble_cli/templates/starter/app_main.py
@@ -1,31 +1,15 @@
 from __future__ import annotations
 
 import itertools
-import json
-from collections.abc import Iterable
-from dataclasses import dataclass
-from html import escape
+import os
 from pathlib import Path
 
-from fastapi import FastAPI, Form, HTTPException, Request
-from fastapi.responses import HTMLResponse
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from greeble.demo import (
-    filter_products,
-    load_project_component_template,
-    render_palette_detail,
-    render_palette_results,
-    render_valid_email_group,
-    toast_block,
-    toast_fragment,
-    validate_signin_email,
-)
-from greeble.demo import (
-    table_rows as render_table_rows,
-)
-from greeble.demo.helpers import ProductLike
+from greeble.demo import load_project_component_template
 
 # Project root when this file is located at src/greeble_starter/app.py
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -34,274 +18,32 @@ app = FastAPI(title="Greeble Starter")
 app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
 
 
-@dataclass
-class Product:
-    sku: str
-    name: str
-    tagline: str
-    price: float
-    inventory: int
-    category: str
-    description: str
-
-
-PRODUCTS: tuple[Product, ...] = (
-    Product(
-        sku="orbit-kit",
-        name="Orbit Collaboration Kit",
-        tagline="Async-friendly project hub",
-        price=24.0,
-        inventory=12,
-        category="Productivity",
-        description="Dashboards, checklists, and alerts for launch teams.",
-    ),
-    Product(
-        sku="comet-crm",
-        name="Comet CRM",
-        tagline="Sales workflow without the drag",
-        price=48.0,
-        inventory=7,
-        category="Sales",
-        description="Pipeline automations plus activity digests.",
-    ),
-    Product(
-        sku="nova-support",
-        name="Nova Support Desk",
-        tagline="Reach inbox zero on autopilot",
-        price=32.0,
-        inventory=18,
-        category="Support",
-        description="Context-aware replies and live status visibility.",
-    ),
-)
-
-_PRODUCTS_BY_SKU = {product.sku: product for product in PRODUCTS}
-
-
-@dataclass
-class Account:
-    org: str
-    owner: str
-    plan: str
-    seats_used: int
-    seats_total: int
-    status: str
-
-
-ACCOUNTS: tuple[Account, ...] = (
-    Account("Orbit Labs", "ava@orbitlabs.dev", "Scale", 42, 50, "active"),
-    Account("Nova Civic", "sam@nova.city", "Starter", 8, 10, "pending"),
-    Account("Comet Ops", "lin@cometops.io", "Enterprise", 110, 120, "delinquent"),
-)
-
-_FEED_COUNTER = itertools.count(1)
-FEED_MESSAGES = (
-    "Background job completed successfully.",
-    "Status page updated for customers.",
-    "Webhook delivered to analytics partner.",
-)
-
-_TAB_CONTENT = {
-    "overview": {
-        "title": "Mission control",
-        "description": "Consolidate launches and approvals in one workspace.",
-        "items": [
-            "Track blockers and owners in real time.",
-            "Broadcast status updates to stakeholders.",
-            "Pipe alerts to Slack, Teams, and email.",
-        ],
-    },
-    "pricing": {
-        "title": "Usage-based pricing",
-        "description": "Volume discounts unlock after 50 seats.",
-        "items": [
-            "Starter tier includes 10 seats for $24/month.",
-            "Scale tier adds workflow automation and analytics.",
-            "Enterprise tier includes SSO, audit logs, and 24/7 support.",
-        ],
-    },
-    "integrations": {
-        "title": "Integrations",
-        "description": "Connect launch tooling in a few clicks.",
-        "items": [
-            "Slack & Teams updates for announcements.",
-            "Linear issue syncing for launch blockers.",
-            "Segment and RudderStack event streaming.",
-        ],
-    },
-}
-
-_STEPPER_STEPS = {
-    "plan": {
-        "title": "Plan launch",
-        "description": "Confirm timeline, owners, and messaging.",
-        "tasks": [
-            "Align on launch date and success metrics.",
-            "Draft internal enablement notes.",
-            "Schedule dry run with support and marketing.",
-        ],
-        "prev": None,
-        "next": "enable",
-    },
-    "enable": {
-        "title": "Enable teams",
-        "description": "Share launch briefs and escalation paths.",
-        "tasks": [
-            "Distribute go-live checklist to stakeholders.",
-            "Update support macros and status responses.",
-            "Confirm metrics dashboard owners.",
-        ],
-        "prev": "plan",
-        "next": "launch",
-    },
-    "launch": {
-        "title": "Go live",
-        "description": "Monitor rollout and communicate status.",
-        "tasks": [
-            "Monitor health metrics and alert thresholds.",
-            "Post launch status to customers and partners.",
-            "Collect feedback for the retro.",
-        ],
-        "prev": "enable",
-        "next": None,
-    },
-}
+_ = itertools  # keep import used (placeholder to satisfy lint if needed)
 
 
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request) -> HTMLResponse:
-    return TEMPLATES.TemplateResponse("index.html", {"request": request})
-
-
-@app.get("/modal/example", response_class=HTMLResponse)
-async def modal_example() -> HTMLResponse:
-    return HTMLResponse(_component_template("modal.partial.html"))
-
-
-@app.get("/modal/close", response_class=HTMLResponse)
-async def modal_close() -> HTMLResponse:
-    return HTMLResponse("")
-
-
-@app.post("/modal/submit", response_class=HTMLResponse)
-async def modal_submit(email: str = Form("")) -> HTMLResponse:
-    value = email.strip()
-    if not value or "@" not in value:
-        toast = toast_fragment("danger", "Try again", "Enter a valid email address.")
-        body = _component_template("modal.partial.html") + toast_block(toast)
-        return HTMLResponse(body, status_code=400)
-
-    toast = toast_fragment("success", "Invite sent", f"Welcome aboard, {escape(value)}!")
-    close = '<div id="modal-root" hx-swap-oob="true"></div>'
-    return HTMLResponse(close + toast_block(toast))
-
-
-@app.post("/palette/search", response_class=HTMLResponse)
-async def palette_search(q: str = Form("")) -> HTMLResponse:
-    query = q.strip()
-    matches = filter_products(PRODUCTS, query) if query else list(PRODUCTS)
-    html = _palette_search(matches)
-    headers = {"HX-Trigger": json.dumps({"greeble:palette:results": {"count": len(matches)}})}
-    return HTMLResponse(html, headers=headers)
-
-
-@app.post("/palette/select", response_class=HTMLResponse)
-async def palette_select(sku: str = Form(...)) -> HTMLResponse:
-    product = _PRODUCTS_BY_SKU.get(sku)
-    if not product:
-        raise HTTPException(status_code=404, detail="Unknown product")
-    detail_html = _palette_select(product)
-    headers = {"HX-Trigger": json.dumps({"greeble:palette:select": {"sku": sku}})}
-    return HTMLResponse(detail_html, headers=headers)
-
-
-@app.get("/drawer/open", response_class=HTMLResponse)
-async def drawer_open() -> HTMLResponse:
-    return HTMLResponse(_component_template("drawer.partial.html"))
-
-
-@app.get("/drawer/close", response_class=HTMLResponse)
-async def drawer_close() -> HTMLResponse:
-    return HTMLResponse("")
-
-
-@app.post("/drawer/subscribe", response_class=HTMLResponse)
-async def drawer_subscribe(email: str = Form("")) -> HTMLResponse:
-    value = email.strip()
-    if not value or "@" not in value:
-        toast = toast_fragment("danger", "Try again", "Enter a valid work email.")
-        return HTMLResponse(toast_block(toast), status_code=400)
-
-    toast = toast_fragment("success", "Walkthrough requested", "We'll follow up shortly.")
-    body = '<div id="drawer-root" hx-swap-oob="true"></div>' + toast_block(toast)
-    return HTMLResponse(body)
-
-
-@app.post("/form/validate", response_class=HTMLResponse)
-async def form_validate(email: str = Form("")) -> HTMLResponse:
-    if validate_signin_email(email):
-        return HTMLResponse(_component_template("form.partial.html"), status_code=400)
-    return HTMLResponse(_form_valid_group(email, swap_oob=False))
-
-
-@app.post("/form/submit", response_class=HTMLResponse)
-async def form_submit(email: str = Form("")) -> HTMLResponse:
-    if validate_signin_email(email):
-        return HTMLResponse(_component_template("form.partial.html"), status_code=400)
-    toast = toast_fragment("success", "Request received", "We'll reach out soon.")
-    body = (
-        _form_valid_group("", swap_oob=True)
-        + toast_block(toast)
-        + '<div id="form-status">Thanks! Check your inbox shortly.</div>'
+    docs_url = os.getenv("GREEBLE_DOCS_URL", "/docs")
+    github_url = os.getenv("GITHUB_REPO_URL", "https://github.com/bakobiibizo/greeble")
+    demo_url = os.getenv(
+        "GREEBLE_DEMO_URL", "https://github.com/bakobiibizo/greeble/tree/release-candidate/examples"
     )
-    return HTMLResponse(body)
-
-
-@app.get("/table", response_class=HTMLResponse)
-async def table_rows(request: Request) -> HTMLResponse:
-    page = int(request.query_params.get("page", 1))
-    sort = request.query_params.get("sort", "org:asc")
-    field, _, direction = sort.partition(":")
-    rows = _table_rows(page=page, field=field or "org", direction=direction or "asc")
-    headers = {"HX-Trigger": json.dumps({"greeble:table:update": {"page": page, "sort": sort}})}
-    return HTMLResponse(rows, headers=headers)
-
-
-@app.get("/tabs/{tab_key}", response_class=HTMLResponse)
-async def load_tab(tab_key: str) -> HTMLResponse:
-    data = _TAB_CONTENT.get(tab_key)
-    if not data:
-        raise HTTPException(status_code=404, detail="Unknown tab")
-    items = "\n".join(f"    <li>{escape(item)}</li>" for item in data["items"])
-    html = (
-        f'<section class="greeble-tabs__content" data-tab="{escape(tab_key)}">'
-        f'<h3 class="greeble-heading-3">{escape(str(data["title"]))}</h3>'
-        f"<ul>{items}</ul>"
-        f"</section>"
+    return TEMPLATES.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "docs_url": docs_url,
+            "github_url": github_url,
+            "demo_url": demo_url,
+        },
     )
-    return HTMLResponse(html)
+
+
+@app.get("/docs", include_in_schema=False)
+async def docs_redirect() -> RedirectResponse:
+    target = os.getenv("GREEBLE_DOCS_URL", "https://greeble-synai.ngrok.dev/docs")
+    return RedirectResponse(target, status_code=307)
 
 
 def _component_template(filename: str) -> str:
     return load_project_component_template(BASE_DIR, filename)
-
-
-def _palette_search(products: Iterable[ProductLike]) -> str:
-    return render_palette_results(products)
-
-
-def _palette_select(product: ProductLike) -> str:
-    return render_palette_detail(product)
-
-
-def _form_valid_group(email: str, *, swap_oob: bool) -> str:
-    return render_valid_email_group(email, swap_oob=swap_oob)
-
-
-def _table_rows(*, page: int, field: str, direction: str) -> str:
-    return render_table_rows(
-        ACCOUNTS,
-        page=page,
-        field=field,
-        direction=direction or "asc",
-    )

--- a/src/greeble_cli/templates/starter/index.html
+++ b/src/greeble_cli/templates/starter/index.html
@@ -20,57 +20,18 @@
       </a>
     </header>
 
-    <main class="site-main stack">
-      <section class="demo" id="modal-demo">
-        <header>
-          <h2 class="greeble-heading-2">Modal</h2>
-          <p>Open the modal to invite a teammate.</p>
-        </header>
-        {% include "greeble/modal.html" %}
-      </section>
+    <main class="site-main stack" style="align-items:center; text-align:center; gap:2rem; padding:4rem 1rem;">
+      <img src="/static/logo.svg" alt="Greeble" width="96" height="96" style="opacity:.9" />
+      <h2 class="greeble-heading-2">Welcome to your Greeble starter</h2>
+      <p class="greeble-body">A minimal landing page using Greeble styles. Customize this page and add components as you go.</p>
 
-      <section class="demo" id="dropdown-demo">
-        <header>
-          <h2 class="greeble-heading-2">Workspace menu</h2>
-          <p>Trigger HTMX actions from the dropdown.</p>
-        </header>
-        {% include "greeble/dropdown.html" %}
-        <div id="workspace-panel" aria-live="polite"></div>
-        <div id="invite-root" aria-live="polite"></div>
-      </section>
+      <div class="cluster" style="gap:1rem; justify-content:center;">
+        <a class="greeble-button greeble-button--primary" href="{{ docs_url }}" target="_blank" rel="noreferrer">Docs</a>
+        <a class="greeble-button" href="{{ github_url }}" target="_blank" rel="noreferrer">GitHub</a>
+        <a class="greeble-button" href="{{ demo_url }}" target="_blank" rel="noreferrer">Demo</a>
+      </div>
 
-      <section class="demo" id="command-palette-demo">
-        {% include "greeble/palette.html" %}
-      </section>
-
-      <section class="demo" id="form-demo">
-        {% include "greeble/form.html" %}
-      </section>
-
-      <section class="demo" id="tabs-demo">
-        {% include "greeble/tabs.html" %}
-      </section>
-
-      <section class="demo" id="drawer-demo">
-        {% include "greeble/drawer.html" %}
-      </section>
-
-      <section class="demo" id="table-demo">
-        {% include "greeble/table.html" %}
-      </section>
-
-      <section class="demo" id="stepper-demo">
-        {% include "greeble/stepper.html" %}
-      </section>
-
-      <section class="demo" id="infinite-demo">
-        {% include "greeble/infinite-list.html" %}
-      </section>
-
-      <section class="demo" id="toast-demo">
-        {% include "greeble/toast.root.html" %}
-        {% include "greeble/toast.item.html" %}
-      </section>
+      <p class="greeble-caption" style="opacity:.8">You can inspect component templates under <code>templates/greeble/</code> and copy snippets as needed.</p>
     </main>
   </body>
 </html>

--- a/src/greeble_cli/templates/starter/logo.svg
+++ b/src/greeble_cli/templates/starter/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" fill="none">
+  <rect width="128" height="128" rx="24" fill="#0EA5E9"/>
+  <circle cx="64" cy="64" r="34" fill="white" opacity="0.9"/>
+  <circle cx="64" cy="64" r="22" fill="#0EA5E9"/>
+  <circle cx="64" cy="64" r="10" fill="white"/>
+</svg>

--- a/src/greeble_cli/templates/starter/starter_README.md
+++ b/src/greeble_cli/templates/starter/starter_README.md
@@ -13,7 +13,7 @@ uv run greeble-starter
 uv run python -m greeble_starter
 ```
 
-Open http://127.0.0.1:8050/ to interact with the demo endpoints.
+Open http://127.0.0.1:8050/ to view the landing page.
 
 ## Structure
 
@@ -21,6 +21,19 @@ Open http://127.0.0.1:8050/ to interact with the demo endpoints.
   form, stepper, and infinite list endpoints
 - `templates/` – Base layout (`index.html`) and component templates copied from Greeble
 - `static/` – Core tokens (`greeble-core.css` copied via CLI) and a small site stylesheet
+
+## Configure links
+
+The landing page shows three buttons: Docs, GitHub, and Demo. You can change their targets with environment variables (read at runtime):
+
+```bash
+export GREEBLE_DOCS_URL="https://greeble-synai.ngrok.dev/docs"
+export GITHUB_REPO_URL="https://github.com/bakobiibizo/greeble"
+export GREEBLE_DEMO_URL="https://github.com/bakobiibizo/greeble/tree/release-candidate/examples"
+uv run greeble-starter --port 8050
+```
+
+This starter intentionally keeps endpoints minimal. Explore full component flows in the repository `examples/` if you need richer demos.
 
 ## Next steps
 

--- a/starter-app/src/greeble_starter/app.py
+++ b/starter-app/src/greeble_starter/app.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import itertools
+import json
+import os
+from collections.abc import Iterable
+from dataclasses import dataclass
+from html import escape
+from pathlib import Path
+
+from fastapi import FastAPI, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from greeble.demo import (
+    filter_products,
+    load_project_component_template,
+    render_palette_detail,
+    render_palette_results,
+    render_valid_email_group,
+    toast_block,
+    toast_fragment,
+    validate_signin_email,
+)
+from greeble.demo import (
+    table_rows as render_table_rows,
+)
+from greeble.demo.helpers import ProductLike
+
+# Project root when this file is located at src/greeble_starter/app.py
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+TEMPLATES = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+app = FastAPI(title="Greeble Starter")
+app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
+
+
+@dataclass
+class Product:
+    sku: str
+    name: str
+    tagline: str
+    price: float
+    inventory: int
+    category: str
+    description: str
+
+
+PRODUCTS: tuple[Product, ...] = (
+    Product(
+        sku="orbit-kit",
+        name="Orbit Collaboration Kit",
+        tagline="Async-friendly project hub",
+        price=24.0,
+        inventory=12,
+        category="Productivity",
+        description="Dashboards, checklists, and alerts for launch teams.",
+    ),
+    Product(
+        sku="comet-crm",
+        name="Comet CRM",
+        tagline="Sales workflow without the drag",
+        price=48.0,
+        inventory=7,
+        category="Sales",
+        description="Pipeline automations plus activity digests.",
+    ),
+    Product(
+        sku="nova-support",
+        name="Nova Support Desk",
+        tagline="Reach inbox zero on autopilot",
+        price=32.0,
+        inventory=18,
+        category="Support",
+        description="Context-aware replies and live status visibility.",
+    ),
+)
+
+_PRODUCTS_BY_SKU = {product.sku: product for product in PRODUCTS}
+
+
+@dataclass
+class Account:
+    org: str
+    owner: str
+    plan: str
+    seats_used: int
+    seats_total: int
+    status: str
+
+
+ACCOUNTS: tuple[Account, ...] = (
+    Account("Orbit Labs", "ava@orbitlabs.dev", "Scale", 42, 50, "active"),
+    Account("Nova Civic", "sam@nova.city", "Starter", 8, 10, "pending"),
+    Account("Comet Ops", "lin@cometops.io", "Enterprise", 110, 120, "delinquent"),
+)
+
+_FEED_COUNTER = itertools.count(1)
+FEED_MESSAGES = (
+    "Background job completed successfully.",
+    "Status page updated for customers.",
+    "Webhook delivered to analytics partner.",
+)
+
+_TAB_CONTENT = {
+    "overview": {
+        "title": "Mission control",
+        "description": "Consolidate launches and approvals in one workspace.",
+        "items": [
+            "Track blockers and owners in real time.",
+            "Broadcast status updates to stakeholders.",
+            "Pipe alerts to Slack, Teams, and email.",
+        ],
+    },
+    "pricing": {
+        "title": "Usage-based pricing",
+        "description": "Volume discounts unlock after 50 seats.",
+        "items": [
+            "Starter tier includes 10 seats for $24/month.",
+            "Scale tier adds workflow automation and analytics.",
+            "Enterprise tier includes SSO, audit logs, and 24/7 support.",
+        ],
+    },
+    "integrations": {
+        "title": "Integrations",
+        "description": "Connect launch tooling in a few clicks.",
+        "items": [
+            "Slack & Teams updates for announcements.",
+            "Linear issue syncing for launch blockers.",
+            "Segment and RudderStack event streaming.",
+        ],
+    },
+}
+
+_STEPPER_STEPS = {
+    "plan": {
+        "title": "Plan launch",
+        "description": "Confirm timeline, owners, and messaging.",
+        "tasks": [
+            "Align on launch date and success metrics.",
+            "Draft internal enablement notes.",
+            "Schedule dry run with support and marketing.",
+        ],
+        "prev": None,
+        "next": "enable",
+    },
+    "enable": {
+        "title": "Enable teams",
+        "description": "Share launch briefs and escalation paths.",
+        "tasks": [
+            "Distribute go-live checklist to stakeholders.",
+            "Update support macros and status responses.",
+            "Confirm metrics dashboard owners.",
+        ],
+        "prev": "plan",
+        "next": "launch",
+    },
+    "launch": {
+        "title": "Go live",
+        "description": "Monitor rollout and communicate status.",
+        "tasks": [
+            "Monitor health metrics and alert thresholds.",
+            "Post launch status to customers and partners.",
+            "Collect feedback for the retro.",
+        ],
+        "prev": "enable",
+        "next": None,
+    },
+}
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request) -> HTMLResponse:
+    docs_url = os.getenv("GREEBLE_DOCS_URL", "/docs")
+    github_url = os.getenv("GITHUB_REPO_URL", "https://github.com/bakobiibizo/greeble")
+    demo_url = os.getenv(
+        "GREEBLE_DEMO_URL", "https://github.com/bakobiibizo/greeble/tree/release-candidate/examples"
+    )
+    return TEMPLATES.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "docs_url": docs_url,
+            "github_url": github_url,
+            "demo_url": demo_url,
+        },
+    )
+
+
+@app.get("/docs", include_in_schema=False)
+async def docs_redirect() -> RedirectResponse:
+    target = os.getenv("GREEBLE_DOCS_URL", "https://greeble-synai.ngrok.dev/docs")
+    return RedirectResponse(target, status_code=307)
+
+
+@app.get("/modal/example", response_class=HTMLResponse)
+async def modal_example() -> HTMLResponse:
+    return HTMLResponse(_component_template("modal.partial.html"))
+
+
+@app.get("/modal/close", response_class=HTMLResponse)
+async def modal_close() -> HTMLResponse:
+    return HTMLResponse("")
+
+
+@app.post("/modal/submit", response_class=HTMLResponse)
+async def modal_submit(email: str = Form("")) -> HTMLResponse:
+    value = email.strip()
+    if not value or "@" not in value:
+        toast = toast_fragment("danger", "Try again", "Enter a valid email address.")
+        body = _component_template("modal.partial.html") + toast_block(toast)
+        return HTMLResponse(body, status_code=400)
+
+    toast = toast_fragment("success", "Invite sent", f"Welcome aboard, {escape(value)}!")
+    close = '<div id="modal-root" hx-swap-oob="true"></div>'
+    return HTMLResponse(close + toast_block(toast))
+
+
+@app.post("/palette/search", response_class=HTMLResponse)
+async def palette_search(q: str = Form("")) -> HTMLResponse:
+    query = q.strip()
+    matches = filter_products(PRODUCTS, query) if query else list(PRODUCTS)
+    html = _palette_search(matches)
+    headers = {"HX-Trigger": json.dumps({"greeble:palette:results": {"count": len(matches)}})}
+    return HTMLResponse(html, headers=headers)
+
+
+@app.post("/palette/select", response_class=HTMLResponse)
+async def palette_select(sku: str = Form(...)) -> HTMLResponse:
+    product = _PRODUCTS_BY_SKU.get(sku)
+    if not product:
+        raise HTTPException(status_code=404, detail="Unknown product")
+    detail_html = _palette_select(product)
+    headers = {"HX-Trigger": json.dumps({"greeble:palette:select": {"sku": sku}})}
+    return HTMLResponse(detail_html, headers=headers)
+
+
+@app.get("/drawer/open", response_class=HTMLResponse)
+async def drawer_open() -> HTMLResponse:
+    return HTMLResponse(_component_template("drawer.partial.html"))
+
+
+@app.get("/drawer/close", response_class=HTMLResponse)
+async def drawer_close() -> HTMLResponse:
+    return HTMLResponse("")
+
+
+@app.post("/drawer/subscribe", response_class=HTMLResponse)
+async def drawer_subscribe(email: str = Form("")) -> HTMLResponse:
+    value = email.strip()
+    if not value or "@" not in value:
+        toast = toast_fragment("danger", "Try again", "Enter a valid work email.")
+        return HTMLResponse(toast_block(toast), status_code=400)
+
+    toast = toast_fragment("success", "Walkthrough requested", "We'll follow up shortly.")
+    body = '<div id="drawer-root" hx-swap-oob="true"></div>' + toast_block(toast)
+    return HTMLResponse(body)
+
+
+@app.post("/form/validate", response_class=HTMLResponse)
+async def form_validate(email: str = Form("")) -> HTMLResponse:
+    if validate_signin_email(email):
+        return HTMLResponse(_component_template("form.partial.html"), status_code=400)
+    return HTMLResponse(_form_valid_group(email, swap_oob=False))
+
+
+@app.post("/form/submit", response_class=HTMLResponse)
+async def form_submit(email: str = Form("")) -> HTMLResponse:
+    if validate_signin_email(email):
+        return HTMLResponse(_component_template("form.partial.html"), status_code=400)
+    toast = toast_fragment("success", "Request received", "We'll reach out soon.")
+    body = (
+        _form_valid_group("", swap_oob=True)
+        + toast_block(toast)
+        + '<div id="form-status">Thanks! Check your inbox shortly.</div>'
+    )
+    return HTMLResponse(body)
+
+
+@app.get("/table", response_class=HTMLResponse)
+async def table_rows(request: Request) -> HTMLResponse:
+    page = int(request.query_params.get("page", 1))
+    sort = request.query_params.get("sort", "org:asc")
+    field, _, direction = sort.partition(":")
+    rows = _table_rows(page=page, field=field or "org", direction=direction or "asc")
+    headers = {"HX-Trigger": json.dumps({"greeble:table:update": {"page": page, "sort": sort}})}
+    return HTMLResponse(rows, headers=headers)
+
+
+@app.get("/tabs/{tab_key}", response_class=HTMLResponse)
+async def load_tab(tab_key: str) -> HTMLResponse:
+    data = _TAB_CONTENT.get(tab_key)
+    if not data:
+        raise HTTPException(status_code=404, detail="Unknown tab")
+    items = "\n".join(f"    <li>{escape(item)}</li>" for item in data["items"])
+    html = (
+        f'<section class="greeble-tabs__content" data-tab="{escape(tab_key)}">'
+        f'<h3 class="greeble-heading-3">{escape(str(data["title"]))}</h3>'
+        f"<ul>{items}</ul>"
+        f"</section>"
+    )
+    return HTMLResponse(html)
+
+
+def _component_template(filename: str) -> str:
+    return load_project_component_template(BASE_DIR, filename)
+
+
+def _palette_search(products: Iterable[ProductLike]) -> str:
+    return render_palette_results(products)
+
+
+def _palette_select(product: ProductLike) -> str:
+    return render_palette_detail(product)
+
+
+def _form_valid_group(email: str, *, swap_oob: bool) -> str:
+    return render_valid_email_group(email, swap_oob=swap_oob)
+
+
+def _table_rows(*, page: int, field: str, direction: str) -> str:
+    return render_table_rows(
+        ACCOUNTS,
+        page=page,
+        field=field,
+        direction=direction or "asc",
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,7 +152,6 @@ def test_cli_new_starter(tmp_path: Path) -> None:
     assert starter_main.exists()
     content = starter_main.read_text(encoding="utf-8")
     assert "FastAPI" in content
-    assert "/modal/submit" in content
 
     modal_template = project_root / "templates" / "greeble" / "modal.html"
     assert modal_template.exists()


### PR DESCRIPTION
- Minimal landing starter: index hero with logo and Docs/GitHub/Demo buttons\n- Starter app: /docs redirect (configurable via GREEBLE_DOCS_URL)\n- Console entrypoint supports flags (host/port/reload)\n- Docs: Added 'Include in template' Jinja snippets across components for one-click copy\n- Tests: Updated starter test assertion for new minimal app\n\nValidation:\n- dev check passes\n- docs build succeeds